### PR TITLE
Parallelisation of ring pairs containment

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 pName=jts-utils
 pGroup=de.topobyte
-pVersion=0.4.0
+pVersion=0.4.1

--- a/src/main/java/de/topobyte/jts/utils/PolygonHelper.java
+++ b/src/main/java/de/topobyte/jts/utils/PolygonHelper.java
@@ -138,12 +138,9 @@ public class PolygonHelper
 			candidates.addAll(rings);
 			candidates.remove(r);
 			Polygon p1 = ringToPolygon.get(r);
-			for (LinearRing c : candidates) {
-				Polygon p2 = ringToPolygon.get(c);
-				if (p1.contains(p2)) {
-					graph.addEdge(r, c);
-				}
-			}
+			candidates.parallelStream().
+					filter(c -> p1.contains(ringToPolygon.get(c))).
+					forEach(c -> graph.addEdge(r, c));
 		}
 
 		// Assemble polygons with holes based on degree of the nodes


### PR DESCRIPTION
Parallelization is implemented in creating MoltiPolygon from linear Rings. Based on the profiling application, it is seen that some large osm entities (like big lakes eg. [Merowe Reservoir](https://www.openstreetmap.org/relation/2937979) ) take too much time to build geometry. Parallelization decreases build time by 80%  (depending on the machine, in this case, 8 CPU & 16GB memory compared with multithreaded vs single-threaded) 